### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,6 @@ Raphaël JavaScript Library Converter
 
 Ready. Set. Raphael. will convert contents from an SVG file to Raphaël JavaScript code.
 
-Online Conversion Tool
-----
-
-Please visit [www.readysetraphael.com](http://www.readysetraphael.com/ "Ready Set Raphael") to use our automatic converter for your projects.
-
 Usage
 --------------
 


### PR DESCRIPTION
Online converter site expired in late 2021 and the domain is being camped by a referral site for a paper-writing scam service. Should probably remove or replace the URL so folks aren't forwarded to a predatory site.